### PR TITLE
Added the Profile/README.md and pull_request_template.md files

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.yaml
+++ b/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,112 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["kind/bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please, fill this form to help us improve the project.
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: Please describe below a concise explanation of what you're experiencing
+      placeholder: A concise description of what you're experiencing...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Please describe below a concise explanation of what you expected to happen.
+      placeholder: A concise description of what you expected to happen...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run '...'
+        4. See error...
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Workaround (if any)
+      description: Please provide any manual steps that allow you to resolve the issue
+      placeholder: What are the steps you followed to resolve the issue?
+    validations:
+      required: false
+  - type: dropdown
+    id: openshift-version
+    attributes:
+      label: OpenShift Version
+      description: What version of OpenShift are you running?
+      options:
+        - OpenStack
+        - OKD
+        - CodeReady Containers
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: other-openshift-version
+    attributes:
+      label: Openshift Version
+      description: If selected other, which version of OpenShift are you running?
+      placeholder: Please fill the version...
+    validations:
+      required: false
+  - type: dropdown
+    id: openshift-infrastructure
+    attributes:
+      label: Openshift Infrastructure
+      description: On what infrastructure is OpenShift running on, if known?
+      options:
+        - Baremetal
+        - OSP
+        - RHV
+        - AWS
+        - other
+    validations:
+      required: false
+  - type: input
+    id: other-openshift-infrastructure
+    attributes:
+      label: Openshift Infrastructure
+      description: If selected other, what infrastructure is OpenShift running on, if known?
+      placeholder: Please fill the infrastructure...
+    validations:
+      required: false
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+    validations:
+      required: false
+  - type: textarea
+    id: opendatahub-version
+    attributes:
+      label: Open Data Hub Version
+      description: Please attach relevant kfdef manifest if applicable
+      render: yml
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. (This will be automatically formatted into code, so no need for backticks)
+      render: shell

--- a/ISSUE_TEMPLATE/feature_request.yaml
+++ b/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest an idea for this project
+title: "[Feature Request]: "
+labels: ["kind/enhancement","feature" ,"untriaged"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please, fill this form to help us improve the project.
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature description
+      description: Please describe below a clear and concise exposition of what you want to happen.
+      placeholder: Tell us what you want to happen...
+    validations:
+      required: true
+  - type: textarea
+    id: related-to-a-problem?
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Please provide below a clear and concise description of what the problem is.
+      placeholder: For example, "I'm always frustrated when...
+    validations:
+      required: false
+  - type: textarea
+    id: describe-alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: Please let us know about other solutions you've tried or researched.
+      placeholder: Tell us about alternatives you've considered...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      placeholder: You might want to link to related issues here, if you haven't already...
+      description: |
+        Please add any other context or screenshots about the feature request here.
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes in detail -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Merge criteria:
+<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+
+- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
+- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
+- [ ] The developer has manually tested the changes and verified that the changes work

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,51 @@
+### Welcome to Open Data Hub 
+Open Data Hub (ODH) is an open source project based on Kubeflow that provides open source AI tools for running large and distributed AI workloads on OpenShift Container Platform. Currently, the Open Data Hub project provides open source tools for data storage, distributed AI and Machine Learning (ML) workflows, Jupyter Notebook development environment and monitoring. 
+
+#### Benefits of Open Data Hub 
+
+ODH is a meta-project that integrates open source projects into a practical solution. It aims to foster collaboration between communities, vendors, user-enterprises, and academics following open source best practices. The open source community can experiment and develop intelligent applications without incurring high costs and having to master the complexity of modern machine learning and artificial intelligence software stacks. 
+
+**Contribution Guidelines**:  
+[https://github.com/opendatahub-io/opendatahub-community/blob/master/contributing.md](https://github.com/opendatahub-io/opendatahub-community/blob/master/contributing.md)
+
+**Release notes**:  
+[https://opendatahub.io/docs/roadmap/release-notes.html](https://opendatahub.io/docs/roadmap/release-notes.html)
+
+**Roadmap**:  
+[https://opendatahub.io/docs/roadmap/future.html](https://opendatahub.io/docs/roadmap/future.html)
+
+**Getting Started**:  
+[https://opendatahub.io/docs/getting-started/quick-installation.html](https://opendatahub.io/docs/getting-started/quick-installation.html)
+
+##
+
+### Repositories
+
+ - **Core/Main Repositories**
+	 * [odh-manifests](https://github.com/opendatahub-io/odh-manifests): A repository for Open Data Hub components Kustomize manifests. 
+	 * [opendatahub-operator](https://github.com/opendatahub-io/opendatahub-operator): A repository that helps to deploy, monitor and manage the lifecycle of Kubeflow. Built using the Operator Framework which offers an open source toolkit to build, test, package operators and manage the lifecycle of operators.
+	 * [odh-dashboard](https://github.com/opendatahub-io/odh-dashboard): A dashboard for Open Data Hub components. Shows what's installed and what's available for installation, as well as, links to component UIs and links to component documentation.
+	 * [kfp-tekton](https://github.com/opendatahub-io/kfp-tekton): Project bringing Kubeflow Pipelines and Tekton together. The current code allows you run Kubeflow Pipelines with Tekton backend end to end.
+
+  - **Tools**
+  	 *  [kubeflow](https://github.com/opendatahub-io/kubeflow): This repository contains the code of kubeflow the cloud-native platform for machine learning operations - pipelines, training and deployment.
+  	 *  [manifests](https://github.com/opendatahub-io/manifests): The Kubeflow Manifests repository is organized under three (3) main directories, which include manifests for installing: `apps`,  `common`, `contrib`
+  	 * [traefik-proxy](https://github.com/opendatahub-io/traefik-proxy):  This project contains what JupyterHub need to dynamically configure the routes of a traefik proxy server
+
+
+  - **Utilities** 
+	  * [jupyterhub-singleuser-profiles](https://github.com/opendatahub-io/jupyterhub-singleuser-profiles): This library helps to manage and configure singleuser JupyterHub servers deployed by KubeSpawner.
+	  * [s2i-lab-elyra](https://github.com/opendatahub-io/s2i-lab-elyra): This image contains Elyra and all the dependencies and configurations needed to run as a part of OpenDataHub's JupyterHub Environment.
+ 	 * [opendatahub.io](https://github.com/opendatahub-io/opendatahub.io):  Contains the webpage source code 
+ 	 * [opendatahub-community](https://github.com/opendatahub-io/opendatahub-community): This is the starting point for joining and contributing to the Open Data Hub community.
+ 	 * [jupyterhub-odh](https://github.com/opendatahub-io/jupyterhub-odh): This repository contains an example of a customised deployment of JupyterHub for OpenShift, which uses the same OpenShift cluster as the deployment is running in, as the authentication provider.
+
+ - **Template Repositories**
+	 * [odh-template-sig](https://github.com/opendatahub-io/odh-template-sig) Repository template for Open Data Hub Special Interest Groups.
+	 
+- **ODH Tutorials**
+
+ 	 
+ - **Backup Repos** 
+	 * [landscapeapp](https://github.com/opendatahub-io/landscapeapp): The landscapeapp is an upstream NPM module that supports building interactive landscape websites such as the CNCF Cloud Native Landscape and the LF Artificial Intelligence Landscape.
+


### PR DESCRIPTION
Hello all, this pull request contains a proposal about structuring the GitHub organization opendatahub-io. By using a special functionality of GitHub (1) we can display an overview page where the visitor could navigate himself into the repositories easier.  

(1) .github repository : https://www.freecodecamp.org/news/how-to-use-the-dot-github-repository/

My proposal is trying to solve (in a way) the non-semantic listing of the repositories. Github's default listing of the repositories is by title or the last modified time,  etc which actually does not give any information regarding the structure (which is the core software, what is the module/library etc). As a consequence, this discourages the open-source community to get involved. So, the idea was to list and categorize the repositories according to the project's intended purpose, subject area, or other important qualities, give initial quick how-to's and help the community to easily jump into our projects.

Long story short, please, take the time to review it and propose alternatives or extra features. 

PS: On this PR I uploaded as well the latest pull_request_template.md that we are using because in this way it can be visible in all the repositories under the org. (except if every repository should have its PR_template file)
